### PR TITLE
Use illuminate Str:: functions for Laravel 6 compatibility

### DIFF
--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -2,6 +2,7 @@
 
 namespace Laracodes\Presenter;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model;
 
 abstract class Presenter
@@ -25,7 +26,7 @@ abstract class Presenter
      */
     public function __isset($property)
     {
-        return method_exists($this, camel_case($property));
+        return method_exists($this, Str::camel($property));
     }
 
     /**
@@ -34,12 +35,12 @@ abstract class Presenter
      */
     public function __get($property)
     {
-        $camel_property = camel_case($property);
+        $camel_property = Str::camel($property);
 
         if (method_exists($this, $camel_property)) {
             return $this->{$camel_property}();
         }
 
-        return $this->model->{snake_case($property)};
+        return $this->model->{Str::snake($property)};
     }
 }


### PR DESCRIPTION
Laravel 6 removed the `str_` and `array_` helper functions, in favour of the functions in the `Illuminate\Support\Str|Arr` classes (https://laravel.com/docs/6.x/upgrade#helpers). While they can be reinstated by the addition of a helpers package, this isn't there by default. This means that this package no longer works out of the box on L6.

This package already required "`illuminate/support": "~5.0|^6.0"`, so we have access to the `Str` class. This PR changes the camel case and snake case functions to use those from the `Str` package, which should give L6 compatibility.